### PR TITLE
Reset searchTerm and this.inputInnerRef.value when value is picked

### DIFF
--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -108,6 +108,7 @@ class WrapperSelect extends React.PureComponent {
         valueLabel: label,
         searchTerm: null
       }, () => {
+        this.inputInnerRef.value = ''
         this.props.onChange(newValue);
       })
     }

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -105,7 +105,8 @@ class WrapperSelect extends React.PureComponent {
     if (value != newValue) {
       this.setState({
         value: newValue,
-        valueLabel: label
+        valueLabel: label,
+        searchTerm: null
       }, () => {
         this.props.onChange(newValue);
       })


### PR DESCRIPTION
Currently if you start writing something in the input field and then use your mouse to select one of the suggestions, the searchTerm is still showing instead of the value selected. I propose either doing like the suggested code change by resetting the field, or by setting the searchTerm field to the value of the input.