### PR TITLE
Make Styled-Components A Peer Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   "peerDependencies": {
     "react": "~15.4.2 || ^16.2.0",
     "react-dom": "~15.4.2 || ^16.2.0",
-    "styled-components": "2.1.1"
+    "styled-components": "2.1.1 - 3.x"
   },
   "dependencies": {
     "@webcomponents/shadydom": "1.0.12",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "react-dom": "^16.2.0",
     "regenerator-runtime": "^0.11.1",
     "sinon": "^2.3.5",
+    "styled-components": "2.1.1",
     "stylelint": "^7.11.1",
     "stylelint-config-standard": "^16.0.0",
     "webpack": "^3.4.1",
@@ -90,6 +91,7 @@
   "peerDependencies": {
     "react": "~15.4.2 || ^16.2.0",
     "react-dom": "~15.4.2 || ^16.2.0"
+    "styled-components": "2.1.1",
   },
   "dependencies": {
     "@webcomponents/shadydom": "1.0.12",
@@ -99,7 +101,6 @@
     "prop-types": "15.6.1",
     "react-click-outside": "3.0.1",
     "react-shadow": "16.2.0",
-    "styled-components": "2.1.1",
     "uuid": "^3.1.0"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -90,8 +90,8 @@
   },
   "peerDependencies": {
     "react": "~15.4.2 || ^16.2.0",
-    "react-dom": "~15.4.2 || ^16.2.0"
-    "styled-components": "2.1.1",
+    "react-dom": "~15.4.2 || ^16.2.0",
+    "styled-components": "2.1.1"
   },
   "dependencies": {
     "@webcomponents/shadydom": "1.0.12",


### PR DESCRIPTION
👋 This PR makes `styled-components` a peer dependency. Consumers of this library are presumably already using `styled-components` in their top level projects, and running two versions of styled-components on a page can cause unexpected results.

https://github.com/styled-components/styled-components/issues/1032
https://github.com/styled-components/styled-components/issues/633

I'm currently aliasing `styled-components` in my project with webpack to avoid using both versions but as I update styled-components I will be running the risk of introducing breaking changes that this library doesn't support.

There's more info here: https://www.styled-components.com/docs/faqs#i-am-a-library-author-should-i-bundle-styledcomponents-with-my-library

Hope this is helpful + please LMK if you have any questions.

Also, if you're open to it, we've been running this package with versions of styled-components as recent as 3.3, so it could be helpful to bump the version or just expand the range of acceptable peer versions